### PR TITLE
Map app port and rely on repo Laravel source

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Este projeto demonstra como configurar uma aplicação Laravel utilizando Docker
 ## Pré-requisitos
 
 - Docker e Docker Compose instalados em sua máquina.
-- Acesso à internet para que o Docker baixe as imagens necessárias e o Composer obtenha o Laravel durante o build.
+- Acesso à internet para que o Docker baixe as imagens necessárias e para instalar o Laravel com o Composer antes de subir os containers.
 
 ## Subindo o projeto
 
@@ -16,7 +16,13 @@ Este projeto demonstra como configurar uma aplicação Laravel utilizando Docker
 docker compose up -d
 ```
 
-A primeira execução pode demorar, pois o Composer irá baixar o Laravel dentro do container `app`.
+Certifique-se de que o código do Laravel já está presente na raiz deste repositório. Caso ainda não exista, execute:
+
+```bash
+composer create-project laravel/laravel .
+```
+
+Após a instalação, você pode subir os containers normalmente.
 
 3. Acesse `http://localhost` no navegador para verificar se a aplicação Laravel está rodando.
 
@@ -24,7 +30,7 @@ A primeira execução pode demorar, pois o Composer irá baixar o Laravel dentro
 
 ## Estrutura dos Containers
 
-- **app**: container PHP-FPM que faz o build do Laravel durante a criação da imagem.
+- **app**: container PHP-FPM que utiliza o código do Laravel presente na raiz do repositório.
 - **nginx**: servidor web que expõe a aplicação na porta 80.
 - **mysql**: banco de dados MySQL na porta 3306.
 - **elasticsearch**: serviço de busca e armazenamento de logs.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
       context: ./docker/php
     volumes:
       - ./:/var/www
+    ports:
+      - "9000:9000"
     networks:
       - laravel
 

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -20,10 +20,10 @@ WORKDIR /var/www
 # Copy existing application directory contents
 COPY . /var/www
 
-# Install Laravel (latest)
-RUN if [ ! -f artisan ]; then \
-    composer create-project laravel/laravel . --prefer-dist; \
-    fi
+# The Laravel application should already be present in the repository.
+# Previously the image downloaded Laravel during build time which
+# prevented editing the source outside the container. This step was
+# removed so the existing project is used as-is.
 
 # Set permissions
 RUN chown -R www-data:www-data /var/www


### PR DESCRIPTION
## Summary
- expose php-fpm on port 9000 so all services are accessible from the host
- remove Laravel installation from the Dockerfile and expect code in repo
- document new workflow and composer step in README

## Testing
- `docker compose config` *(fails: docker not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685d7a9fdcbc83209699fbdc5f95de73