### PR TITLE
Add log sidecar with Filebeat and ELK

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,45 @@
+# Stack de Logs com Filebeat, Elasticsearch e Kibana
+
+Este projeto demonstra como configurar um sidecar de logs utilizando Filebeat para enviar arquivos JSON para o Elasticsearch e visualizá-los no Kibana.
+
+## Requisitos
+
+- [Docker](https://www.docker.com/) e [Docker Compose](https://docs.docker.com/compose/) instalados.
+
+### Instalação do Docker
+
+1. Baixe e instale o Docker conforme a documentação oficial: <https://docs.docker.com/get-docker/>
+2. Instale o Docker Compose: <https://docs.docker.com/compose/install/>
+
+## Subindo o ambiente
+
+Com o Docker instalado, clone este repositório e execute:
+
+```bash
+docker-compose up
+```
+
+Isso iniciará três containers:
+
+- **elasticsearch** – Armazena e indexa os logs. Disponível em `http://localhost:9200`.
+- **kibana** – Interface web para visualizar os dados do Elasticsearch. Disponível em `http://localhost:5601`.
+- **filebeat** – Responsável por coletar arquivos de log em `/app/logs` e enviá-los para o Elasticsearch.
+
+Todos os serviços compartilham a mesma rede interna e podem se comunicar entre si.
+
+## Adicionando logs de teste
+
+Coloque arquivos `.log` no diretório `./logs`. Por exemplo, já existe um arquivo `./logs/test.log` com o seguinte conteúdo:
+
+```json
+{"timestamp": "2025-06-26T13:00:00Z", "level": "INFO", "message": "Log de teste", "service": "laravel-app"}
+```
+
+O Filebeat irá ler automaticamente os arquivos presentes nesse diretório e enviá-los para o Elasticsearch, utilizando o índice `logs-sidecar-%{+yyyy.MM.dd}`.
+
+## Acessando as aplicações
+
+- Acesse o Kibana em: [http://localhost:5601](http://localhost:5601)
+- Acesse o Elasticsearch em: [http://localhost:9200](http://localhost:9200)
+
+Agora você pode explorar os logs coletados e visualizar dashboards pelo Kibana.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+version: '3.8'
+services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.13.0
+    container_name: elasticsearch
+    environment:
+      - discovery.type=single-node
+      - ES_JAVA_OPTS=-Xms512m -Xmx512m
+    ports:
+      - "9200:9200"
+    networks:
+      - log-net
+  kibana:
+    image: docker.elastic.co/kibana/kibana:8.13.0
+    container_name: kibana
+    ports:
+      - "5601:5601"
+    environment:
+      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+    depends_on:
+      - elasticsearch
+    networks:
+      - log-net
+  filebeat:
+    image: docker.elastic.co/beats/filebeat:8.13.0
+    container_name: filebeat
+    user: root
+    volumes:
+      - ./filebeat.yml:/usr/share/filebeat/filebeat.yml:ro
+      - ./logs:/app/logs:ro
+    depends_on:
+      - elasticsearch
+    networks:
+      - log-net
+networks:
+  log-net:
+    driver: bridge

--- a/filebeat.yml
+++ b/filebeat.yml
@@ -1,0 +1,11 @@
+filebeat.inputs:
+  - type: log
+    paths:
+      - /app/logs/*.log
+    json.keys_under_root: true
+    json.add_error_key: true
+output.elasticsearch:
+  hosts: ["http://elasticsearch:9200"]
+  index: "logs-sidecar-%{+yyyy.MM.dd}"
+setup.kibana:
+  host: "http://kibana:5601"

--- a/logs/test.log
+++ b/logs/test.log
@@ -1,0 +1,1 @@
+{"timestamp": "2025-06-26T13:00:00Z", "level": "INFO", "message": "Log de teste", "service": "laravel-app"}


### PR DESCRIPTION
## Summary
- add `docker-compose.yml` with Elasticsearch, Kibana and Filebeat services
- configure Filebeat with `filebeat.yml`
- add example log file
- document usage in `README.md`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d7faa9768832082c1d7f17cb4fe85