### PR TITLE
Habilita segurança no stack de logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,27 @@ O Filebeat irá ler automaticamente os arquivos presentes nesse diretório e env
 - Acesse o Elasticsearch em: [http://localhost:9200](http://localhost:9200)
 
 Agora você pode explorar os logs coletados e visualizar dashboards pelo Kibana.
+
+## Autenticação e acesso seguro
+
+Com a stack subida, o Elasticsearch inicia com segurança ativada e define a senha do usuário `elastic` como `changeme` (variável `ELASTIC_PASSWORD`).
+
+Caso prefira gerar um token de acesso, execute:
+
+```bash
+docker-compose exec elasticsearch bin/elasticsearch-create-enrollment-token -s kibana
+```
+
+Kibana e Filebeat já estão configurados para se autenticar usando `elastic` / `changeme`.
+
+### Acessando o Kibana
+
+Acesse [http://localhost:5601](http://localhost:5601) no navegador e faça login com `elastic` / `changeme`.
+
+### Testando a conexão com o Elasticsearch
+
+Execute o comando abaixo para verificar o acesso usando autenticação:
+
+```bash
+curl -u elastic:changeme http://localhost:9200
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     container_name: elasticsearch
     environment:
       - discovery.type=single-node
+      - xpack.security.enabled=true
+      - ELASTIC_PASSWORD=changeme
       - ES_JAVA_OPTS=-Xms512m -Xmx512m
     ports:
       - "9200:9200"
@@ -17,6 +19,8 @@ services:
       - "5601:5601"
     environment:
       - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+      - ELASTICSEARCH_USERNAME=elastic
+      - ELASTICSEARCH_PASSWORD=changeme
     depends_on:
       - elasticsearch
     networks:

--- a/filebeat.yml
+++ b/filebeat.yml
@@ -6,6 +6,11 @@ filebeat.inputs:
     json.add_error_key: true
 output.elasticsearch:
   hosts: ["http://elasticsearch:9200"]
+  username: "elastic"
+  password: "changeme"
   index: "logs-sidecar-%{+yyyy.MM.dd}"
+
+setup.template.name: "logs-sidecar"
+setup.template.pattern: "logs-sidecar-*"
 setup.kibana:
   host: "http://kibana:5601"


### PR DESCRIPTION
## Summary
- enable security on Elasticsearch
- configure Kibana and Filebeat with credentials
- update Filebeat output settings
- document authentication steps

## Testing
- `docker compose config` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685d8c283c0c8320b66ef67a9610ce87