### PR TITLE
Update Kibana auth to use service token

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,31 @@ Agora você pode explorar os logs coletados e visualizar dashboards pelo Kibana.
 
 Com a stack subida, o Elasticsearch inicia com segurança ativada e define a senha do usuário `elastic` como `changeme` (variável `ELASTIC_PASSWORD`).
 
-Caso prefira gerar um token de acesso, execute:
+### ⚙️ Geração do token para Kibana
 
-```bash
-docker-compose exec elasticsearch bin/elasticsearch-create-enrollment-token -s kibana
-```
+1. Após subir o container do Elasticsearch com:
+   ```bash
+   docker compose up -d elasticsearch
+   ```
+   Acesse o container:
+   ```bash
+   docker exec -it elasticsearch bash
+   ```
+   Gere o token de serviço do Kibana:
+   ```bash
+   elasticsearch-create-enrollment-token --scope kibana
+   ```
+   Copie o token retornado e defina em um arquivo `.env`:
+   ```env
+   KIBANA_SERVICE_TOKEN=eyJ2ZXIiOiI... (cole aqui)
+   ```
+   Suba os serviços restantes:
+   ```bash
+   docker compose up -d
+   ```
+   Acesse o Kibana em: http://localhost:5601
 
-Kibana e Filebeat já estão configurados para se autenticar usando `elastic` / `changeme`.
+Filebeat continua autenticando com `elastic` / `changeme`.
 
 ### Acessando o Kibana
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,8 +19,7 @@ services:
       - "5601:5601"
     environment:
       - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
-      - ELASTICSEARCH_USERNAME=elastic
-      - ELASTICSEARCH_PASSWORD=changeme
+      - ELASTICSEARCH_SERVICEACCOUNTTOKEN=${KIBANA_SERVICE_TOKEN}
     depends_on:
       - elasticsearch
     networks:


### PR DESCRIPTION
## Summary
- use service account token for Kibana auth
- document how to generate and configure the token

## Testing
- `docker compose config` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685d8fd019d88320857a78cb76801a0c